### PR TITLE
fix class name in README: MutableValue -> Mutable

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ Reducers are classes that implement the following interface:
 
 ```kotlin
 interface Reducer<State, Action> {
-    fun reduce(state: MutableValue<State>, action: Action): List<Effect<Action>>
+    fun reduce(state: Mutable<State>, action: Action): List<Effect<Action>>
 }
 ```
 
@@ -322,7 +322,7 @@ The simplest example of this is a logging reducer, which logs every dispatched a
 class LoggingReducer(override val innerReducer: Reducer<AppState, AppAction>)
     : HigherOrderReducer<AppState, AppAction> {
     override fun reduce(
-        state: MutableValue<AppState>,
+        state: Mutable<AppState>,
         action: AppAction
     ): List<Effect<AppAction>> {
         Log.i(


### PR DESCRIPTION
Hi, thanks for this inspiring project!

## Summary
<!-- MANDATORY: Describe clearly and concisely what this PR changes -->

`MutableValue` in README should be `Mutable`.

## Relationships
<!-- MANDATORY: Mention any issues or PRs that are connected to this -->
<!-- DO NOT OPEN A PULL REQUEST THAT DOES NO CLOSE/REF AN ISSUE -->

Sorry I didn't create an issue for this but is such a trivial I think(Feel free to close this PR)

## Technical considerations
<!-- OPTIONAL:
      - Describe how the changes are implemented, list the different parts the changes consist of if it's more than one
      - Point out specific commits, explain why you did what you did
      - Are there other possible solutions that might seem more obvious? Tell us why you didn't go with those
-->

## Tests
<!-- MANDATORY: If it includes tests, just a :white_check_mark: is enough. If it doesn't, explain why or link other issues where we add those tests -->

## Review pointers
<!-- MANDATORY: Give pointers to help reviewers validate the changes, give a list of things that should be tested, show before/after screenshots, etc. -->

<!-- Uncomment the following section if you don't want the PR to be merged yet, or you want to specify merge permissions. Otherwise everyone is welcome to merge -->
<!--
## Merge permissions
⚠️ DO NOT MERGE
-->
