### PR TITLE
Rename dispatch to send for consistency with TCA

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,11 +70,11 @@ limitations under the License.
 This is a high level overview of the different parts of the architecture. 
 
 - **Views** This is anything that can subscribe to the store to be notified of state changes. Normally this happens only in UI elements, but other elements of the app could also react to state changes.
-- **Action** Simple structs that describe an event, normally originated by the user, but also from other sources or in response to other actions (from Effects). The only way to change the state is through actions. Views dispatch actions to the store which handles them in the main thread as they come.
-- **Store** The central hub of the application. Contains the whole state of the app, handles the dispatched actions passing them to the reducers and fires Effects.
+- **Action** Simple structs that describe an event, normally originated by the user, but also from other sources or in response to other actions (from Effects). The only way to change the state is through actions. Views send actions to the store which handles them in the main thread as they come.
+- **Store** The central hub of the application. Contains the whole state of the app, handles the actions, passing them to the reducers and fires Effects.
 - **State** The single source of truth for the whole app. This data class will be probably empty when the application start and will be filled after every action. 
-- **Reducers** Reducers are pure functions that take the state and an action and produce a new state. Simple as that. They optionally result in an array of Effects that will asynchronously dispatch further actions. All business logic should reside in them.
-- **Effects** As mentioned, Reducers optionally produce these after handling an action. They are classes that return an optional action. All the effects emitted from a reducer will be batched, meaning the state change will only be emitted once all actions are dispatched.
+- **Reducers** Reducers are pure functions that take the state and an action and produce a new state. Simple as that. They optionally result in an array of Effects that will asynchronously send further actions. All business logic should reside in them.
+- **Effects** As mentioned, Reducers optionally produce these after handling an action. They are classes that return an optional action. All the effects emitted from a reducer will be batched, meaning the state change will only be emitted once all actions are handled.
 - **Subscriptions** Subscriptions are emitting actions based on some underling observable API and/or state changes.   
 
 There's one global `Store` and one `AppState`. But we can *view* into the store to get sub-stores that only work on one part of the state. More on that later.
@@ -85,14 +85,14 @@ There's also one main `Reducer` and multiple sub-reducers that handle a limited 
 
 ### Store & State
 
-The `Store` exposes a flow which emits the whole state of the app every time there's a change and a method to dispatch actions that will modify that state.  The `State` is just a data class that contains ALL the state of the application. It also includes the local state of all the specific modules that need local state. More on this later.
+The `Store` exposes a flow which emits the whole state of the app every time there's a change and a method to send actions that will modify that state.  The `State` is just a data class that contains ALL the state of the application. It also includes the local state of all the specific modules that need local state. More on this later.
 
 The store interface looks like this:
 
 ```kotlin
 interface Store<State, Action : Any> {
     val state: Flow<State>
-    fun dispatch(actions: List<Action>)
+    fun send(actions: List<Action>)
     // more code
 }
 ```
@@ -109,10 +109,10 @@ createStore(
 )
 ```
 
-actions are dispatched like this:
+actions are sent like this:
 
 ```kotlin
-store.dispatch(AppAction.BackPressed)
+store.send(AppAction.BackPressed)
 ```
 
 and views can subscribe like this:
@@ -156,16 +156,16 @@ sealed class AppAction {
 }
 ```
 
-So to dispatch an `EditAction` to a store that takes `AppActions` we would do
+So to send an `EditAction` to a store that takes `AppActions` we would do
 
 ```kotlin
-store.dispatch(AppAction.Edit(EditAction.TitleChanged("new title"))
+store.send(AppAction.Edit(EditAction.TitleChanged("new title")))
 ```
 
 But if the store is a view that takes `EditAction`s we'd do it like this:
 
 ```kotlin
-store.dispatch(EditAction.TitleChanged("new title"))
+store.send(EditAction.TitleChanged("new title"))
 ```
 
 ### Reducers & Effects
@@ -180,7 +180,7 @@ interface Reducer<State, Action> {
 
 The idea is they take the state and an action and modify the state depending on the action and its payload.
 
-In order to dispatch actions asynchronously we use `Effect`s. Reducers return an array of `Effect`s. The store waits for those effects and dispatches whatever action they emit, if any.
+In order to send actions asynchronously we use `Effect`s. Reducers return an array of `Effect`s. The store waits for those effects and sends whatever action they emit, if any.
 
 An effect interface is also straightforward:
 
@@ -280,7 +280,7 @@ class MutableStateFlowStore<State, Action : Any> private constructor(
 
 This method on `Store` takes two functions, one to map the global state into local state and another one to map local action to global action.
 
-Different modules or features of the app use different store views so they are only able to listen to changes to parts of the state and are only able to dispatch certain actions.
+Different modules or features of the app use different store views so they are only able to listen to changes to parts of the state and are only able to send certain actions.
 
 ### Local State
 

--- a/komposable-architecture/src/main/java/com/toggl/komposable/architecture/Effect.kt
+++ b/komposable-architecture/src/main/java/com/toggl/komposable/architecture/Effect.kt
@@ -11,8 +11,8 @@ interface Effect<out Action> {
      * Executes the effect. This operation can produce side effects and it's the
      * responsibility of the class implementing this interface to change threads
      * to prevent blocking the UI when needed
-     * @return An action that will be dispatched again for further processing
-     * @see Store.dispatch
+     * @return An action that will be sent again for further processing
+     * @see Store.send
      */
     suspend fun execute(): Action?
 }

--- a/komposable-architecture/src/main/java/com/toggl/komposable/architecture/Store.kt
+++ b/komposable-architecture/src/main/java/com/toggl/komposable/architecture/Store.kt
@@ -17,18 +17,35 @@ interface Store<State, Action : Any> {
 
     /**
      * Sends a actions to be processed by the internal reducer
+     * If multiple actions are sent, the state will still only emit
+     * once all actions are processed in a batch
+     * @see state
+     */
+    fun send(actions: List<Action>)
+
+    /**
+     * Convenience method to send a single action to be processed by the internal reducer
+     * @see Store.send
+     */
+    fun send(action: Action) =
+        send(listOf(action))
+
+    /**
+     * Sends a actions to be processed by the internal reducer
      * If multiple actions are dispatched, the state will still only emit
      * once all actions are processed in a batch
      * @see state
      */
+    @Deprecated("Use send(List<Action>)", ReplaceWith("this.send(actions)"))
     fun dispatch(actions: List<Action>)
 
     /**
      * Convenience method to send a single action to be processed by the internal reducer
      * @see Store.dispatch
      */
+    @Deprecated("Use send(Action)", ReplaceWith("this.send(action)"))
     fun dispatch(action: Action) =
-        dispatch(listOf(action))
+        send(listOf(action))
 
     /**
      * Transforms this store in a more specific store that can only emit

--- a/komposable-architecture/src/main/java/com/toggl/komposable/internal/MutableStateFlowStore.kt
+++ b/komposable-architecture/src/main/java/com/toggl/komposable/internal/MutableStateFlowStore.kt
@@ -112,9 +112,11 @@ internal class MutableStateFlowStore<State, Action : Any> private constructor(
         }
     }
 
-    override fun dispatch(actions: List<Action>) {
+    override fun send(actions: List<Action>) {
         if (actions.isEmpty()) return
 
         dispatchFn(actions)
     }
+
+    override fun dispatch(actions: List<Action>) = send(actions)
 }

--- a/komposable-architecture/src/test/java/com/toggl/komposable/StoreExceptionHandlingTests.kt
+++ b/komposable-architecture/src/test/java/com/toggl/komposable/StoreExceptionHandlingTests.kt
@@ -17,14 +17,14 @@ class StoreExceptionHandlingTests : StoreCoroutineTest() {
 
     @Test
     fun `reduce exception should be handled`() = runTest {
-        testStore.dispatch(TestAction.ThrowExceptionAction)
+        testStore.send(TestAction.ThrowExceptionAction)
         runCurrent()
         coVerify(exactly = 1) { testExceptionHandler.handleException(TestException) }
     }
 
     @Test
     fun `effect exception should be handled`() = runTest {
-        testStore.dispatch(TestAction.StartExceptionThrowingEffectAction)
+        testStore.send(TestAction.StartExceptionThrowingEffectAction)
         runCurrent()
         coVerify(exactly = 1) { testExceptionHandler.handleException(TestException) }
     }

--- a/komposable-architecture/src/test/java/com/toggl/komposable/StoreReducerTests.kt
+++ b/komposable-architecture/src/test/java/com/toggl/komposable/StoreReducerTests.kt
@@ -14,14 +14,14 @@ class StoreReducerTests : StoreCoroutineTest() {
 
     @Test
     fun `reducer shouldn't be called if the list of dispatched actions is empty`() = runTest {
-        testStore.dispatch(emptyList())
+        testStore.send(emptyList())
         runCurrent()
         coVerify(exactly = 0) { testReducer.reduce(any(), any()) }
     }
 
     @Test
     fun `reducer should be called exactly once if one action is dispatched`() = runTest {
-        testStore.dispatch(TestAction.DoNothingAction)
+        testStore.send(TestAction.DoNothingAction)
         runCurrent()
         coVerify(exactly = 1) { testReducer.reduce(any(), TestAction.DoNothingAction) }
     }
@@ -29,7 +29,7 @@ class StoreReducerTests : StoreCoroutineTest() {
     @Test
     fun `reducer should be called for each action dispatched in order in which they were provided`() = runTest {
         val startUselessEffectAction = TestAction.StartEffectAction(TestEffect(TestAction.DoNothingFromEffectAction))
-        testStore.dispatch(
+        testStore.send(
             listOf(
                 TestAction.DoNothingAction,
                 startUselessEffectAction,
@@ -58,7 +58,7 @@ class StoreReducerTests : StoreCoroutineTest() {
         val changeTestPropertyAction = TestAction.ChangeTestProperty("123")
         val addTestPropertyAction = TestAction.AddToTestProperty("4")
 
-        testStore.dispatch(
+        testStore.send(
             listOf(
                 TestAction.DoNothingAction,
                 changeTestPropertyAction,

--- a/komposable-architecture/src/test/java/com/toggl/komposable/StoreStateTests.kt
+++ b/komposable-architecture/src/test/java/com/toggl/komposable/StoreStateTests.kt
@@ -15,7 +15,7 @@ class StoreStateTests : StoreCoroutineTest() {
     @Test
     fun `state is emitted in batches after all dispatched actions were reduced`() = runTest {
         testStore.state.test {
-            testStore.dispatch(
+            testStore.send(
                 listOf(
                     TestAction.DoNothingAction,
                     TestAction.ChangeTestProperty("123"),
@@ -40,7 +40,7 @@ class StoreStateTests : StoreCoroutineTest() {
     @Test
     fun `new state is emitted only when it's different than the previous one`() = runTest {
         testStore.state.test {
-            testStore.dispatch(
+            testStore.send(
                 listOf(
                     TestAction.DoNothingAction,
                     TestAction.ChangeTestProperty("123"),
@@ -64,7 +64,7 @@ class StoreStateTests : StoreCoroutineTest() {
     @Test
     fun `effects emit new state only after the result state of previously dispatched actions was emitted`() = runTest {
         testStore.state.test {
-            testStore.dispatch(
+            testStore.send(
                 listOf(
                     TestAction.DoNothingAction,
                     TestAction.ChangeTestProperty("123"),

--- a/todo-sample/src/main/java/com/toggl/komposable/sample/todo/TodoScaffold.kt
+++ b/todo-sample/src/main/java/com/toggl/komposable/sample/todo/TodoScaffold.kt
@@ -39,7 +39,7 @@ fun TodoScaffold() {
 
     activity.handleBackPressesEmitting {
         if (backStack.size < 2) activity.finish()
-        else appStore.dispatch(AppAction.BackPressed)
+        else appStore.send(AppAction.BackPressed)
     }
 
     val currentDestination = backStack.last()
@@ -86,7 +86,7 @@ private fun TodoBottomAppBar(appStore: AppStoreViewModel, currentDestination: Ap
     BottomAppBar(cutoutShape = RoundedCornerShape(100)) {
         if (currentDestination == AppDestination.Add) {
             OutlinedButton(
-                onClick = { appStore.dispatch(AppAction.Edit(EditAction.SaveTapped)) }
+                onClick = { appStore.send(AppAction.Edit(EditAction.SaveTapped)) }
             ) {
                 Icon(Icons.Rounded.Check, contentDescription = null)
                 Text(text = "Save")

--- a/todo-sample/src/main/java/com/toggl/komposable/sample/todo/edit/EditPage.kt
+++ b/todo-sample/src/main/java/com/toggl/komposable/sample/todo/edit/EditPage.kt
@@ -34,7 +34,7 @@ fun EditPage() {
             modifier = Modifier.fillMaxWidth(),
             label = { Text("Title") },
             value = editableTodoItem.value.title,
-            onValueChange = { store.dispatch(EditAction.TitleChanged(it)) },
+            onValueChange = { store.send(EditAction.TitleChanged(it)) },
             singleLine = true
         )
         Spacer(modifier = Modifier.height(8.dp))
@@ -42,7 +42,7 @@ fun EditPage() {
             modifier = Modifier.fillMaxWidth().fillMaxHeight(0.5f),
             label = { Text("Description") },
             value = editableTodoItem.value.description,
-            onValueChange = { store.dispatch(EditAction.DescriptionChanged(it)) },
+            onValueChange = { store.send(EditAction.DescriptionChanged(it)) },
             maxLines = 20
         )
         Spacer(modifier = Modifier.height(16.dp))

--- a/todo-sample/src/main/java/com/toggl/komposable/sample/todo/list/ListPage.kt
+++ b/todo-sample/src/main/java/com/toggl/komposable/sample/todo/list/ListPage.kt
@@ -63,7 +63,7 @@ private fun TodoItem(todo: TodoItem) {
 fun AddTodoFab() {
     val listStore = hiltViewModel<ListStoreViewModel>()
     FloatingActionButton(
-        onClick = { listStore.dispatch(ListAction.AddTodoTapped) }
+        onClick = { listStore.send(ListAction.AddTodoTapped) }
     ) {
         Icon(Icons.Rounded.Add, contentDescription = "Add New Todo Item")
     }


### PR DESCRIPTION

## Summary
As discussed in #23, using `send` instead of `dispatch` would be beneficial for individuals and teams that have previous experience with TCA (The Composable Architecture). This PR changes the name to `send`, deprecating the `dispatch` methods.

## Relationships
Closes #23

## Technical considerations
-

## Tests
Existing tests have been updated. No new tests have been added since this is just a rename that doesn't introduce any new behavior.

## Review pointers
As suggested by @semanticer, `@Deprecated` annotations were added, I hope I did them correctly. 