### PR TITLE
Fix: Flow operator functions should not be invoked within composition

### DIFF
--- a/todo-sample/src/main/java/com/toggl/komposable/sample/todo/AppNavigationHost.kt
+++ b/todo-sample/src/main/java/com/toggl/komposable/sample/todo/AppNavigationHost.kt
@@ -13,7 +13,7 @@ fun AppNavigationHost(backStack: List<AppDestination>) {
 
     // extremely naive implementation for purposes of this sample
     if (navController.currentDestination != null) {
-        if (backStack.size > 1) {
+        if (backStack.isNotEmpty()) {
             navController.navigate(backStack.last().route)
         } else {
             navController.popBackStack()

--- a/todo-sample/src/main/java/com/toggl/komposable/sample/todo/AppStoreViewModel.kt
+++ b/todo-sample/src/main/java/com/toggl/komposable/sample/todo/AppStoreViewModel.kt
@@ -2,10 +2,21 @@ package com.toggl.komposable.sample.todo
 
 import androidx.lifecycle.ViewModel
 import com.toggl.komposable.architecture.Store
+import com.toggl.komposable.sample.todo.data.Identity
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
 import javax.inject.Inject
 
 @HiltViewModel
 class AppStoreViewModel @Inject constructor(
     store: Store<AppState, AppAction>
-) : ViewModel(), Store<AppState, AppAction> by store
+) : ViewModel(), ViewStateProvider<AppViewState>, Store<AppState, AppAction> by store {
+    override val viewState: Flow<AppViewState> = state.map { AppViewState(it.identity, it.backStack) }
+    override val initialViewState: AppViewState = AppViewState()
+}
+
+data class AppViewState(
+    val identity: Identity = Identity.Unknown,
+    val backStack: BackStack = listOf(AppDestination.List),
+)

--- a/todo-sample/src/main/java/com/toggl/komposable/sample/todo/Extensions.kt
+++ b/todo-sample/src/main/java/com/toggl/komposable/sample/todo/Extensions.kt
@@ -12,6 +12,10 @@ import kotlin.coroutines.CoroutineContext
 import kotlin.coroutines.EmptyCoroutineContext
 
 @Composable
+fun <ViewState> ViewStateProvider<ViewState>.collectViewStateWhenStarted() =
+    viewState.collectAsStateWhenStarted(initial = initialViewState)
+
+@Composable
 fun <T> Flow<T>.collectAsStateWhenStarted(
     initial: T,
     context: CoroutineContext = EmptyCoroutineContext

--- a/todo-sample/src/main/java/com/toggl/komposable/sample/todo/TodoScaffold.kt
+++ b/todo-sample/src/main/java/com/toggl/komposable/sample/todo/TodoScaffold.kt
@@ -35,7 +35,7 @@ fun TodoScaffold() {
     val activity = LocalContext.current as AppCompatActivity
 
     activity.handleBackPressesEmitting {
-        if (viewState.backStack.size < 2) activity.finish()
+        if (backStack.size < 2) activity.finish()
         else appStore.send(AppAction.BackPressed)
     }
 

--- a/todo-sample/src/main/java/com/toggl/komposable/sample/todo/TodoScaffold.kt
+++ b/todo-sample/src/main/java/com/toggl/komposable/sample/todo/TodoScaffold.kt
@@ -25,20 +25,17 @@ import com.toggl.komposable.sample.todo.data.Identity
 import com.toggl.komposable.sample.todo.edit.EditAction
 import com.toggl.komposable.sample.todo.list.AddTodoFab
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.flow.map
 
 @ExperimentalCoroutinesApi
 @Composable
 fun TodoScaffold() {
     val appStore = hiltViewModel<AppStoreViewModel>()
-    val backStack by appStore.state
-        .map { it.backStack }
-        .collectAsStateWhenStarted(initial = listOf(AppDestination.List))
-
+    val viewState by appStore.collectViewStateWhenStarted()
+    val backStack = viewState.backStack
     val activity = LocalContext.current as AppCompatActivity
 
     activity.handleBackPressesEmitting {
-        if (backStack.size < 2) activity.finish()
+        if (viewState.backStack.size < 2) activity.finish()
         else appStore.send(AppAction.BackPressed)
     }
 
@@ -48,7 +45,7 @@ fun TodoScaffold() {
         floatingActionButton = { if (currentDestination == AppDestination.List) AddTodoFab() },
         floatingActionButtonPosition = FabPosition.Center,
         isFloatingActionButtonDocked = true,
-        bottomBar = { TodoBottomAppBar(appStore, currentDestination) }
+        bottomBar = { TodoBottomAppBar(appStore, currentDestination, viewState.identity) }
     ) {
         AppNavigationHost(
             backStack = backStack
@@ -77,12 +74,7 @@ fun AppCompatActivity.handleBackPressesEmitting(callback: () -> Unit) {
 }
 
 @Composable
-private fun TodoBottomAppBar(appStore: AppStoreViewModel, currentDestination: AppDestination) {
-
-    val identity by appStore.state
-        .map { it.identity }
-        .collectAsStateWhenStarted(initial = Identity.Unknown)
-
+private fun TodoBottomAppBar(appStore: AppStoreViewModel, currentDestination: AppDestination, identity: Identity) {
     BottomAppBar(cutoutShape = RoundedCornerShape(100)) {
         if (currentDestination == AppDestination.Add) {
             OutlinedButton(
@@ -95,7 +87,7 @@ private fun TodoBottomAppBar(appStore: AppStoreViewModel, currentDestination: Ap
         Spacer(modifier = Modifier.weight(1f))
         val identityText = when (identity) {
             Identity.Unknown -> "Loading..."
-            is Identity.User -> (identity as Identity.User).username
+            is Identity.User -> identity.username
         }
         Text(text = identityText, modifier = Modifier.padding(end = 12.dp))
     }

--- a/todo-sample/src/main/java/com/toggl/komposable/sample/todo/ViewStateProvider.kt
+++ b/todo-sample/src/main/java/com/toggl/komposable/sample/todo/ViewStateProvider.kt
@@ -1,0 +1,8 @@
+package com.toggl.komposable.sample.todo
+
+import kotlinx.coroutines.flow.Flow
+
+interface ViewStateProvider<ViewState> {
+    val viewState: Flow<ViewState>
+    val initialViewState: ViewState
+}

--- a/todo-sample/src/main/java/com/toggl/komposable/sample/todo/edit/EditPage.kt
+++ b/todo-sample/src/main/java/com/toggl/komposable/sample/todo/edit/EditPage.kt
@@ -11,19 +11,21 @@ import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.material.TextField
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
-import com.toggl.komposable.sample.todo.data.EditableTodoItem
-import kotlinx.coroutines.flow.map
+import com.toggl.komposable.sample.todo.collectViewStateWhenStarted
 
 @Composable
 fun EditPage() {
     val store = hiltViewModel<EditStoreViewModel>()
-    val editableTodoItem = store.state.map { it.editableTodo }.collectAsState(initial = EditableTodoItem())
+    val editViewState by store.collectViewStateWhenStarted()
+    val editableTodoItem = editViewState.editableTodo
     Column(
-        modifier = Modifier.padding(horizontal = 16.dp, vertical = 32.dp).fillMaxSize(),
+        modifier = Modifier
+            .padding(horizontal = 16.dp, vertical = 32.dp)
+            .fillMaxSize(),
     ) {
         Text(
             text = "Edit Page",
@@ -33,15 +35,17 @@ fun EditPage() {
         TextField(
             modifier = Modifier.fillMaxWidth(),
             label = { Text("Title") },
-            value = editableTodoItem.value.title,
+            value = editableTodoItem.title,
             onValueChange = { store.dispatch(EditAction.TitleChanged(it)) },
             singleLine = true
         )
         Spacer(modifier = Modifier.height(8.dp))
         TextField(
-            modifier = Modifier.fillMaxWidth().fillMaxHeight(0.5f),
+            modifier = Modifier
+                .fillMaxWidth()
+                .fillMaxHeight(0.5f),
             label = { Text("Description") },
-            value = editableTodoItem.value.description,
+            value = editableTodoItem.description,
             onValueChange = { store.dispatch(EditAction.DescriptionChanged(it)) },
             maxLines = 20
         )

--- a/todo-sample/src/main/java/com/toggl/komposable/sample/todo/edit/EditStoreViewModel.kt
+++ b/todo-sample/src/main/java/com/toggl/komposable/sample/todo/edit/EditStoreViewModel.kt
@@ -2,10 +2,21 @@ package com.toggl.komposable.sample.todo.edit
 
 import androidx.lifecycle.ViewModel
 import com.toggl.komposable.architecture.Store
+import com.toggl.komposable.sample.todo.ViewStateProvider
+import com.toggl.komposable.sample.todo.data.EditableTodoItem
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
 import javax.inject.Inject
 
 @HiltViewModel
 class EditStoreViewModel @Inject constructor(
     store: Store<EditState, EditAction>
-) : ViewModel(), Store<EditState, EditAction> by store
+) : ViewModel(), ViewStateProvider<EditViewState>, Store<EditState, EditAction> by store {
+    override val viewState: Flow<EditViewState> = state.map { EditViewState(it.editableTodo) }
+    override val initialViewState: EditViewState = EditViewState()
+}
+
+data class EditViewState(
+    val editableTodo: EditableTodoItem = EditableTodoItem(),
+)

--- a/todo-sample/src/main/java/com/toggl/komposable/sample/todo/list/ListPage.kt
+++ b/todo-sample/src/main/java/com/toggl/komposable/sample/todo/list/ListPage.kt
@@ -14,20 +14,17 @@ import androidx.compose.material.Text
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.Add
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
-import com.toggl.komposable.sample.todo.collectAsStateWhenStarted
+import com.toggl.komposable.sample.todo.collectViewStateWhenStarted
 import com.toggl.komposable.sample.todo.data.TodoItem
-import kotlinx.coroutines.flow.map
 
 @Composable
 fun ListPage() {
-    val list = hiltViewModel<ListStoreViewModel>().state
-        .map { it.todoList }
-        .collectAsStateWhenStarted(initial = emptyList())
-        .value
-    TodoList(list)
+    val listViewState by hiltViewModel<ListStoreViewModel>().collectViewStateWhenStarted()
+    TodoList(listViewState.todoList)
 }
 
 @Composable
@@ -44,7 +41,9 @@ private fun TodoList(todoList: List<TodoItem>) {
         }
     } else {
         Text(
-            modifier = Modifier.fillMaxSize().padding(48.dp),
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(48.dp),
             text = "Add your first Todo!",
             style = MaterialTheme.typography.h3
         )

--- a/todo-sample/src/main/java/com/toggl/komposable/sample/todo/list/ListStoreViewModel.kt
+++ b/todo-sample/src/main/java/com/toggl/komposable/sample/todo/list/ListStoreViewModel.kt
@@ -13,10 +13,7 @@ import javax.inject.Inject
 class ListStoreViewModel @Inject constructor(
     store: Store<ListState, ListAction>
 ) : ViewModel(), ViewStateProvider<ListViewState>, Store<ListState, ListAction> by store {
-
-    override val viewState: Flow<ListViewState>
-        get() = state.map { ListViewState(it.todoList) }
-
+    override val viewState: Flow<ListViewState> = state.map { ListViewState(it.todoList) }
     override val initialViewState: ListViewState = ListViewState()
 }
 

--- a/todo-sample/src/main/java/com/toggl/komposable/sample/todo/list/ListStoreViewModel.kt
+++ b/todo-sample/src/main/java/com/toggl/komposable/sample/todo/list/ListStoreViewModel.kt
@@ -2,10 +2,24 @@ package com.toggl.komposable.sample.todo.list
 
 import androidx.lifecycle.ViewModel
 import com.toggl.komposable.architecture.Store
+import com.toggl.komposable.sample.todo.ViewStateProvider
+import com.toggl.komposable.sample.todo.data.TodoItem
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
 import javax.inject.Inject
 
 @HiltViewModel
 class ListStoreViewModel @Inject constructor(
     store: Store<ListState, ListAction>
-) : ViewModel(), Store<ListState, ListAction> by store
+) : ViewModel(), ViewStateProvider<ListViewState>, Store<ListState, ListAction> by store {
+
+    override val viewState: Flow<ListViewState>
+        get() = state.map { ListViewState(it.todoList) }
+
+    override val initialViewState: ListViewState = ListViewState()
+}
+
+data class ListViewState(
+    val todoList: List<TodoItem> = emptyList(),
+)


### PR DESCRIPTION
## Summary
As mentioned in #25, flows shouldn't be manipulated inside Composables. 

## Relationships

Closes #31

## Technical considerations
We already use this solution internally, we should consider extracting this to the library in the future.  

## Tests
None

## Review pointers
See if the sample app still works. The code is pretty much the same as what we do internally so it's been reviewed already. 
