### PR TITLE
🏗️ Make Effects functional interfaces

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -63,8 +63,8 @@ subprojects {
             allWarningsAsErrors = true
             // Set JVM target to 1.8
             jvmTarget = "1.8"
-            apiVersion = "1.5"
-            languageVersion = "1.5"
+            apiVersion = "1.6"
+            languageVersion = "1.6"
             freeCompilerArgs += ["-Xskip-prerelease-check"]
         }
     }

--- a/komposable-architecture/src/main/java/com/toggl/komposable/architecture/Effect.kt
+++ b/komposable-architecture/src/main/java/com/toggl/komposable/architecture/Effect.kt
@@ -5,7 +5,7 @@ package com.toggl.komposable.architecture
  * This can be anything from cpu/io bound operations to changes that simply affect the UI
  * @see Reducer.reduce
  */
-interface Effect<out Action> {
+fun interface Effect<out Action> {
 
     /**
      * Executes the effect. This operation can produce side effects and it's the


### PR DESCRIPTION
## Summary
This updates the interface definition of Effect to mark it as a functional interface (SAM)

## Technical considerations
<!-- OPTIONAL:
      - Describe how the changes are implemented, list the different parts the changes consist of if it's more than one
      - Point out specific commits, explain why you did what you did
      - Are there other possible solutions that might seem more obvious? Tell us why you didn't go with those
-->
It wasn't possible to have a SAM whose only method was a suspending fun in the version of Kotlin that we were using when building the library. Newer version of Kotlin allow it (hence why I bumped it)

## Tests
No behavioral changes were made. It makes sense for the classes inside the library to be properly inherited, but there are use cases for users to have small, anonymous effects (similar to how Reducers can be full blown classes or not)