### PR TITLE
⏲️ Add the Effect.debounce extension

### DIFF
--- a/komposable-architecture/src/main/java/com/toggl/komposable/extensions/Debounce.kt
+++ b/komposable-architecture/src/main/java/com/toggl/komposable/extensions/Debounce.kt
@@ -1,28 +1,16 @@
 package com.toggl.komposable.extensions
 
 import com.toggl.komposable.architecture.Effect
-import kotlinx.coroutines.Job
-import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.cancellable
 import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.onStart
-import kotlinx.coroutines.sync.withLock
 
 fun <Action> Effect<Action>.debounce(
     id: Any,
     delayMillis: Long,
 ): Effect<Action> = Effect {
     this.run().debounce(delayMillis).onStart {
-        mutex.withLock {
-            cancellationJobs[id]?.forEach {
-                it.cancel(EffectCancellationException.InFlightEffectsCancelled(id))
-            }
-            cancellationJobs.remove(id)
-
-            val job = currentCoroutineContext()[Job]
-            job?.let { cancellationJobs.getOrPut(id) { mutableSetOf() }.add(it) }
-        }
         delay(delayMillis)
-    }.cancellable()
-}
+    }
+}.cancellable(id, true)

--- a/komposable-architecture/src/main/java/com/toggl/komposable/extensions/Debounce.kt
+++ b/komposable-architecture/src/main/java/com/toggl/komposable/extensions/Debounce.kt
@@ -11,7 +11,7 @@ import kotlinx.coroutines.flow.onStart
  *  start emitting their actions.
  *  It does not affect the internal execution of the effect, but a debounced effect can be cancelled,
  *  cancelling it's internal execution.
- *  
+ *
  * @param id The identifier for this debounced effect. Used to manage cancellation.
  * @param delayMillis The amount of time to delay the execution of the effect.
  * @return A new Effect instance that is debounced.

--- a/komposable-architecture/src/main/java/com/toggl/komposable/extensions/Debounce.kt
+++ b/komposable-architecture/src/main/java/com/toggl/komposable/extensions/Debounce.kt
@@ -20,7 +20,6 @@ fun <Action> Effect<Action>.debounce(
     id: Any,
     delayMillis: Long,
 ): Effect<Action> = Effect {
-    this.run().debounce(delayMillis).onStart {
     this.run().onStart {
         delay(delayMillis)
     }

--- a/komposable-architecture/src/main/java/com/toggl/komposable/extensions/Debounce.kt
+++ b/komposable-architecture/src/main/java/com/toggl/komposable/extensions/Debounce.kt
@@ -2,15 +2,26 @@ package com.toggl.komposable.extensions
 
 import com.toggl.komposable.architecture.Effect
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.flow.cancellable
-import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.onStart
 
+/**
+ * Debounces an effect by delaying its execution by the specified amount of time.
+ *  Note that this will only debounce effect if it is executed multiple times within the delay period.
+ *  If effects with the same id are fired emitted faster than the delay indefinitely, they will never
+ *  start emitting their actions.
+ *  It does not affect the internal execution of the effect, but a debounced effect can be cancelled,
+ *  cancelling it's internal execution.
+ *  
+ * @param id The identifier for this debounced effect. Used to manage cancellation.
+ * @param delayMillis The amount of time to delay the execution of the effect.
+ * @return A new Effect instance that is debounced.
+ */
 fun <Action> Effect<Action>.debounce(
     id: Any,
     delayMillis: Long,
 ): Effect<Action> = Effect {
     this.run().debounce(delayMillis).onStart {
+    this.run().onStart {
         delay(delayMillis)
     }
 }.cancellable(id, true)

--- a/komposable-architecture/src/main/java/com/toggl/komposable/extensions/Debounce.kt
+++ b/komposable-architecture/src/main/java/com/toggl/komposable/extensions/Debounce.kt
@@ -1,0 +1,28 @@
+package com.toggl.komposable.extensions
+
+import com.toggl.komposable.architecture.Effect
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.cancellable
+import kotlinx.coroutines.flow.debounce
+import kotlinx.coroutines.flow.onStart
+import kotlinx.coroutines.sync.withLock
+
+fun <Action> Effect<Action>.debounce(
+    id: Any,
+    delayMillis: Long,
+): Effect<Action> = Effect {
+    this.run().debounce(delayMillis).onStart {
+        mutex.withLock {
+            cancellationJobs[id]?.forEach {
+                it.cancel(EffectCancellationException.InFlightEffectsCancelled(id))
+            }
+            cancellationJobs.remove(id)
+
+            val job = currentCoroutineContext()[Job]
+            job?.let { cancellationJobs.getOrPut(id) { mutableSetOf() }.add(it) }
+        }
+        delay(delayMillis)
+    }.cancellable()
+}

--- a/komposable-architecture/src/main/java/com/toggl/komposable/extensions/EffectCancellationExtensions.kt
+++ b/komposable-architecture/src/main/java/com/toggl/komposable/extensions/EffectCancellationExtensions.kt
@@ -10,8 +10,8 @@ import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 
-private val mutex = Mutex()
-private val cancellationJobs: MutableMap<Any, MutableSet<Job>> = mutableMapOf()
+internal val mutex = Mutex()
+internal val cancellationJobs: MutableMap<Any, MutableSet<Job>> = mutableMapOf()
 
 /**
  * Makes an Effect cancellable by associating it with a given ID.

--- a/komposable-architecture/src/main/java/com/toggl/komposable/extensions/EffectCancellationExtensions.kt
+++ b/komposable-architecture/src/main/java/com/toggl/komposable/extensions/EffectCancellationExtensions.kt
@@ -10,8 +10,8 @@ import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 
-internal val mutex = Mutex()
-internal val cancellationJobs: MutableMap<Any, MutableSet<Job>> = mutableMapOf()
+private val mutex = Mutex()
+private val cancellationJobs: MutableMap<Any, MutableSet<Job>> = mutableMapOf()
 
 /**
  * Makes an Effect cancellable by associating it with a given ID.

--- a/komposable-architecture/src/test/java/com/toggl/komposable/effect/EffectDebounceTests.kt
+++ b/komposable-architecture/src/test/java/com/toggl/komposable/effect/EffectDebounceTests.kt
@@ -1,0 +1,107 @@
+package com.toggl.komposable.effect
+
+import app.cash.turbine.turbineScope
+import com.toggl.komposable.architecture.Effect
+import com.toggl.komposable.architecture.ReduceResult
+import com.toggl.komposable.architecture.Reducer
+import com.toggl.komposable.extensions.debounce
+import com.toggl.komposable.scope.DispatcherProvider
+import com.toggl.komposable.test.store.ExhaustiveTestConfig
+import com.toggl.komposable.test.store.test
+import com.toggl.komposable.test.utils.JavaLogger
+import com.toggl.komposable.test.utils.JvmReflectionHandler
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import java.util.logging.Logger
+import kotlin.time.Duration.Companion.milliseconds
+
+class EffectDebounceTests {
+    @Test
+    fun `effects debounce on stores`() = runTest {
+        val reducer = Reducer<Int, String> { state, action ->
+            when (action) {
+                "tap_add" -> ReduceResult(
+                    state,
+                    Effect.fromSuspend {
+                        "add"
+                    }.debounce("debounce", 100),
+                )
+
+                "add" -> ReduceResult(state + 1, Effect.none())
+                else -> ReduceResult(state, Effect.none())
+            }
+        }
+        val testDispatcher = StandardTestDispatcher(testScheduler)
+        val dispatcherProvider = DispatcherProvider(testDispatcher, testDispatcher, testDispatcher)
+        val testCoroutineScope = TestScope(testDispatcher)
+        val exhaustiveConfig = ExhaustiveTestConfig(
+            dispatcherProvider,
+            testCoroutineScope,
+            JavaLogger(Logger.getLogger("TestStore")),
+            reflectionHandler = JvmReflectionHandler(),
+        )
+
+        reducer.test(0, exhaustiveConfig) {
+            send("tap_add")
+            this.advanceTestStoreTimeBy(50.milliseconds)
+            send("tap_add")
+            this.advanceTestStoreTimeBy(50.milliseconds)
+            send("tap_add")
+            this.advanceTestStoreTimeBy(100.milliseconds)
+            this.receive("add") {
+                1
+            }
+            send("tap_add")
+            this.advanceTestStoreTimeBy(100.milliseconds)
+            this.receive("add") {
+                2
+            }
+        }
+    }
+
+    @Test
+    fun `effects debounce`() = runTest {
+        val someState = MutableStateFlow(emptySet<Int>())
+        fun doTheThing(value: Set<Int>): Effect<Set<Int>> {
+            return Effect.fromSuspend {
+                value
+            }.debounce("debouncer", 100)
+        }
+
+        turbineScope {
+            val effect1 = doTheThing(setOf(1)).run()
+                .onEach { someState.value = it }
+                .testIn(this)
+            delay(50)
+            effect1.expectNoEvents()
+            someState.value shouldBe emptySet()
+
+            val effect2 = doTheThing(setOf(2)).run()
+                .onEach { someState.value = it }
+                .testIn(this)
+            delay(50)
+            effect1.awaitError()
+            effect2.expectNoEvents()
+            someState.value shouldBe emptySet()
+
+            val effect3 = doTheThing(setOf(3)).run()
+                .onEach { someState.value = it }
+                .testIn(this)
+            delay(50)
+            effect2.awaitError()
+            effect3.expectNoEvents()
+            someState.value shouldBe emptySet()
+
+            delay(50)
+            effect3.awaitItem() shouldBe setOf(3)
+            effect3.awaitComplete()
+            someState.value shouldBe setOf(3)
+        }
+    }
+}

--- a/samples/todos/src/main/java/com/toggl/komposable/sample/todos/Todos.kt
+++ b/samples/todos/src/main/java/com/toggl/komposable/sample/todos/Todos.kt
@@ -8,9 +8,9 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.toggl.komposable.architecture.ReduceResult
 import com.toggl.komposable.architecture.Reducer
-import com.toggl.komposable.extensions.withSuspendEffect
+import com.toggl.komposable.extensions.debounce
+import com.toggl.komposable.extensions.withEffect
 import com.toggl.komposable.extensions.withoutEffect
-import kotlinx.coroutines.delay
 import java.util.UUID
 
 sealed class TodosAction {
@@ -52,10 +52,7 @@ class TodosReducer : Reducer<TodosState, TodosAction> {
             TodosAction.SortCompletedTodos ->
                 state.copy(todos = state.todos.sortedBy { it.isComplete }).withoutEffect()
             is TodosAction.Todo -> if (action.action is TodoAction.IsCompleteChanged) {
-                state.withSuspendEffect(id = "sort", cancelInFlight = true) {
-                    delay(1000)
-                    TodosAction.SortCompletedTodos
-                }
+                state.withEffect { of(TodosAction.SortCompletedTodos).debounce("sort", 1000) }
             } else {
                 state.withoutEffect()
             }


### PR DESCRIPTION
## Summary
This PR is adding a simpler way to make debounce-able Effects.

## Relationships
Closes #66 

## Technical considerations
You might wonder about the delay I'm adding in the extension. That's added to simulate the plain flow's debounce behavior in our effects. Without it, immediate effects wouldn't respect the debounce and would fire immediately after being started; only effects with some actual work would get debounced and only if they took more time than the next event got fired.

## Tests
✅ ✅ ✅ 

## Review pointers
Try the sample app; Review the extension itself and check the tests.

<!-- Uncomment the following section if you don't want the PR to be merged yet, or you want to specify merge permissions. Otherwise everyone is welcome to merge -->
<!--
## Merge permissions
⚠️ DO NOT MERGE
-->
