### PR TITLE
⚛️ Initial state generation using KSP

### DIFF
--- a/komposable-architecture-compiler/src/main/kotlin/Extensions.kt
+++ b/komposable-architecture-compiler/src/main/kotlin/Extensions.kt
@@ -12,4 +12,4 @@ fun Resolver.getSymbolsAnnotatedWith(kClass: KClass<*>) =
         .filter(KSNode::validate)
 
 fun String.toCamelCase() =
-    first().lowercaseChar() + this.substring(1..length - 1)
+    first().lowercaseChar() + this.substring(1..< length)

--- a/komposable-architecture-compiler/src/main/kotlin/processors/StateMappingSymbolProcessor.kt
+++ b/komposable-architecture-compiler/src/main/kotlin/processors/StateMappingSymbolProcessor.kt
@@ -1,0 +1,134 @@
+package com.toggl.komposable.processors
+
+import com.google.devtools.ksp.KspExperimental
+import com.google.devtools.ksp.getAnnotationsByType
+import com.google.devtools.ksp.getClassDeclarationByName
+import com.google.devtools.ksp.getConstructors
+import com.google.devtools.ksp.processing.CodeGenerator
+import com.google.devtools.ksp.processing.KSPLogger
+import com.google.devtools.ksp.processing.Resolver
+import com.google.devtools.ksp.processing.SymbolProcessor
+import com.google.devtools.ksp.processing.SymbolProcessorEnvironment
+import com.google.devtools.ksp.processing.SymbolProcessorProvider
+import com.google.devtools.ksp.symbol.KSClassDeclaration
+import com.google.devtools.ksp.symbol.KSType
+import com.squareup.kotlinpoet.FileSpec
+import com.squareup.kotlinpoet.FunSpec
+import com.squareup.kotlinpoet.ksp.toClassName
+import com.toggl.komposable.FileGenerationResult
+import com.toggl.komposable.architecture.ChildStates
+import com.toggl.komposable.architecture.ParentPath
+import com.toggl.komposable.getSymbolsAnnotatedWith
+import com.toggl.komposable.toCamelCase
+
+@OptIn(KspExperimental::class)
+class StateMappingSymbolProcessor(
+    codeGenerator: CodeGenerator,
+    logger: KSPLogger,
+) : KotlinPoetSymbolProcessor(codeGenerator, logger) {
+    override fun generateFiles(resolver: Resolver): Sequence<FileGenerationResult> =
+        resolver
+            .getSymbolsAnnotatedWith(ChildStates::class)
+            .map { parentState ->
+                val parentStateClassName = parentState.toClassName()
+                val parentStateTypeName = parentStateClassName.simpleName
+
+                val parentStateArgumentName = parentStateTypeName.toCamelCase()
+
+                parentState
+                    .findChildStateClasses()
+                    .mapNotNull { resolver.getClassDeclarationByName(it.toClassName().canonicalName) }
+                    .fold(parentState.stateMappingFileBuilder()) { fileBuilder, childState ->
+                        val childStateClassName = childState.toClassName()
+                        val childStateTypeName = childStateClassName.simpleName
+                        val childStateArgumentName = childStateTypeName.toCamelCase()
+
+                        fileBuilder
+                            .addFunction(
+                                FunSpec
+                                    .builder("map${parentStateTypeName}To$childStateTypeName")
+                                    .addParameter(parentStateArgumentName, parentState.toClassName())
+                                    .returns(childStateClassName)
+                                    // .trimIndent does not behave the way we expect here, hence the weird format.
+                                    .addCode(
+                                        """return $childStateTypeName(
+    ${buildChildStateConstructorParameterList(childState, parentStateArgumentName)})""",
+                                    )
+                                    .build(),
+                            )
+                            .addFunction(
+                                FunSpec
+                                    .builder("map${childStateTypeName}To$parentStateTypeName")
+                                    .addParameter(parentStateArgumentName, parentStateClassName)
+                                    .addParameter(childStateArgumentName, childStateClassName)
+                                    .returns(parentStateClassName)
+                                    .addCode(
+                                        """return $parentStateArgumentName.copy(
+    ${buildParentStateConstructorParameterList(childState, childStateArgumentName)}    )""",
+                                    )
+                                    .build(),
+                            )
+
+                        fileBuilder
+                    }.build().run(FileGenerationResult::Success)
+            }
+
+    // Yes, we need to do this instead of simply calling getAnnotationsByType<ChildStates>().
+    // Explanation here: https://github.com/google/ksp/issues/888
+    private fun KSClassDeclaration.findChildStateClasses() =
+        annotations
+            .toList()
+            .filter { it.annotationType.resolve().toClassName().canonicalName == ChildStates::class.qualifiedName }
+            .flatMap { it.arguments.toList().single().value as ArrayList<*> }
+            .mapNotNull { it as? KSType }
+
+    private fun buildChildStateConstructorParameterList(
+        childState: KSClassDeclaration,
+        parentStateArgumentName: String,
+    ): String =
+        childState
+            .getConstructors()
+            .first()
+            .parameters
+            .fold(StringBuilder()) { builder, parameter ->
+                val name = parameter.name?.getShortName().orEmpty()
+                val path = parameter
+                    .getAnnotationsByType(ParentPath::class)
+                    .firstOrNull()
+                    ?.path ?: name
+
+                builder.appendLine("$name = $parentStateArgumentName.$path,")
+            }.toString()
+
+    private fun buildParentStateConstructorParameterList(
+        childState: KSClassDeclaration,
+        childStateArgumentName: String,
+    ): String =
+        childState
+            .getConstructors()
+            .first()
+            .parameters
+            .fold(StringBuilder()) { builder, parameter ->
+                val name = parameter.name?.getShortName().orEmpty()
+                val path = parameter
+                    .getAnnotationsByType(ParentPath::class)
+                    .firstOrNull()
+                    ?.path ?: name
+
+                builder.appendLine("    $name = $childStateArgumentName.$path,")
+            }.toString()
+
+    private fun KSClassDeclaration.stateMappingFileBuilder(): FileSpec.Builder {
+        val className = toClassName()
+
+        return FileSpec.builder(
+            packageName = className.packageName,
+            fileName = "${className.simpleName}StateMappings",
+        )
+    }
+}
+
+class StateMappingSymbolProcessorProvider : SymbolProcessorProvider {
+    override fun create(environment: SymbolProcessorEnvironment): SymbolProcessor =
+        StateMappingSymbolProcessor(environment.codeGenerator, environment.logger)
+}

--- a/komposable-architecture-compiler/src/main/kotlin/processors/StateMappingSymbolProcessor.kt
+++ b/komposable-architecture-compiler/src/main/kotlin/processors/StateMappingSymbolProcessor.kt
@@ -50,7 +50,7 @@ class StateMappingSymbolProcessor(
                                     // .trimIndent does not behave the way we expect here, hence the weird format.
                                     .addCode(
                                         """return $childStateTypeName(
-    ${buildChildStateConstructorParameterList(childState, parentStateArgumentName)})""",
+${buildChildStateConstructorParameterList(childState, parentStateArgumentName)})""",
                                     )
                                     .build(),
                             )
@@ -83,7 +83,7 @@ ${buildParentStateConstructorParameterList(childState, parentStateArgumentName, 
                 val name = parameter.name?.getShortName().orEmpty()
                 val path = parameter.getParentPath() ?: name
 
-                builder.appendLine("$name = $parentStateArgumentName.$path,")
+                builder.appendLine("    $name = $parentStateArgumentName.$path,")
             }.toString()
 
     private fun buildParentStateConstructorParameterList(

--- a/komposable-architecture-compiler/src/main/resources/META-INF/services/com.google.devtools.ksp.processing.SymbolProcessorProvider
+++ b/komposable-architecture-compiler/src/main/resources/META-INF/services/com.google.devtools.ksp.processing.SymbolProcessorProvider
@@ -1,1 +1,2 @@
 com.toggl.komposable.processors.ActionMappingSymbolProcessorProvider
+com.toggl.komposable.processors.StateMappingSymbolProcessorProvider

--- a/komposable-architecture-compiler/src/test/kotlin/ActionMappingSymbolProcessorTests.kt
+++ b/komposable-architecture-compiler/src/test/kotlin/ActionMappingSymbolProcessorTests.kt
@@ -1,9 +1,8 @@
 import com.toggl.komposable.processors.ActionMappingSymbolProcessorProvider
 import com.tschuchort.compiletesting.KotlinCompilation
 import com.tschuchort.compiletesting.symbolProcessorProviders
-import io.kotest.matchers.comparables.shouldBeEqualComparingTo
 import io.kotest.matchers.shouldBe
-import io.kotest.matchers.string.shouldBeEqualIgnoringCase
+import sources.ActionSources
 import kotlin.test.Test
 
 class ActionMappingSymbolProcessorTests {
@@ -11,7 +10,7 @@ class ActionMappingSymbolProcessorTests {
     fun `Action mapping methods are generated`() {
         // Arrange
         val compilation = KotlinCompilation().apply {
-            sources = listOf(SourceFiles.appAction, SourceFiles.settingsAction)
+            sources = listOf(ActionSources.appAction, ActionSources.settingsAction)
             symbolProcessorProviders = listOf(ActionMappingSymbolProcessorProvider())
             inheritClassPath = true
             messageOutputStream = System.out
@@ -25,14 +24,14 @@ class ActionMappingSymbolProcessorTests {
 
         val sources = result.kspGeneratedSources()
         sources.size.shouldBe(1)
-        sources.single().readText().shouldBe(SourceFiles.generatedActionExtensionsFile)
+        sources.single().readText().shouldBe(ActionSources.generatedActionExtensionsFile)
     }
 
     @Test
     fun `Action mapping methods are generated on files without a package`() {
         // Arrange
         val compilation = KotlinCompilation().apply {
-            sources = listOf(SourceFiles.appActionWithoutPackage, SourceFiles.settingsActionWithoutPackage)
+            sources = listOf(ActionSources.appActionWithoutPackage, ActionSources.settingsActionWithoutPackage)
             symbolProcessorProviders = listOf(ActionMappingSymbolProcessorProvider())
             inheritClassPath = true
             messageOutputStream = System.out
@@ -46,14 +45,14 @@ class ActionMappingSymbolProcessorTests {
 
         val sources = result.kspGeneratedSources()
         sources.size.shouldBe(1)
-        sources.single().readText().shouldBe(SourceFiles.generatedActionExtensionsFileWithoutPackage)
+        sources.single().readText().shouldBe(ActionSources.generatedActionExtensionsFileWithoutPackage)
     }
 
     @Test
     fun `If a class annotated with @WrapperAction has multiple properties then the compilation fails`() {
         // Arrange
         val compilation = KotlinCompilation().apply {
-            sources = listOf(SourceFiles.appActionWithMultipleProperties, SourceFiles.settingsAction)
+            sources = listOf(ActionSources.appActionWithMultipleProperties, ActionSources.settingsAction)
             symbolProcessorProviders = listOf(ActionMappingSymbolProcessorProvider())
             inheritClassPath = true
             messageOutputStream = System.out

--- a/komposable-architecture-compiler/src/test/kotlin/ActionMappingSymbolProcessorTests.kt
+++ b/komposable-architecture-compiler/src/test/kotlin/ActionMappingSymbolProcessorTests.kt
@@ -1,7 +1,9 @@
 import com.toggl.komposable.processors.ActionMappingSymbolProcessorProvider
 import com.tschuchort.compiletesting.KotlinCompilation
 import com.tschuchort.compiletesting.symbolProcessorProviders
+import io.kotest.matchers.comparables.shouldBeEqualComparingTo
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldBeEqualIgnoringCase
 import kotlin.test.Test
 
 class ActionMappingSymbolProcessorTests {

--- a/komposable-architecture-compiler/src/test/kotlin/SourceFiles.kt
+++ b/komposable-architecture-compiler/src/test/kotlin/SourceFiles.kt
@@ -3,6 +3,15 @@ import org.intellij.lang.annotations.Language
 
 object SourceFiles {
 
+    val settingsState = SourceFile.kotlin(
+        "SettingsState.kt",
+        """
+        package com.toggl.komposable.compiler
+        
+        data class SettingsState(val booleanValue: Boolean)
+        """.trimIndent(),
+    )
+
     val settingsAction = SourceFile.kotlin(
         "SettingsAction.kt",
         """
@@ -20,6 +29,22 @@ object SourceFiles {
     sealed interface SettingsAction {
         data class ChangeSomeSetting(val newValue: Boolean) : SettingsAction
     }
+        """.trimIndent(),
+    )
+
+    val appState = SourceFile.kotlin(
+        "AppState.kt",
+        """
+        package com.toggl.komposable.compiler
+        
+        import com.toggl.komposable.architecture.ChildStates
+        import com.toggl.komposable.compiler.SettingsState
+        
+        @ChildStates(SettingsState::class)
+        data class AppState(
+            val someList: List<String>,
+            val booleanValue: Boolean
+        )
         """.trimIndent(),
     )
 
@@ -89,5 +114,18 @@ public fun mapAppActionToSettingsAction(appAction: AppAction): SettingsAction? =
 
 public fun mapSettingsActionToAppAction(settingsAction: SettingsAction): AppAction.Settings =
     AppAction.Settings(settingsAction)
+"""
+
+    @Language("kotlin")
+    val generatedStateExtensionsFile = """package com.toggl.komposable.compiler
+
+public fun mapAppStateToSettingsState(appState: AppState): SettingsState = SettingsState(
+    booleanValue = appState.booleanValue,
+)
+
+public fun mapSettingsStateToAppState(appState: AppState, settingsState: SettingsState): AppState =
+    appState.copy(
+        booleanValue = settingsState.booleanValue,
+    )
 """
 }

--- a/komposable-architecture-compiler/src/test/kotlin/StateMappingSymbolProcessorTests.kt
+++ b/komposable-architecture-compiler/src/test/kotlin/StateMappingSymbolProcessorTests.kt
@@ -1,0 +1,28 @@
+import com.toggl.komposable.processors.StateMappingSymbolProcessorProvider
+import com.tschuchort.compiletesting.KotlinCompilation
+import com.tschuchort.compiletesting.symbolProcessorProviders
+import io.kotest.matchers.shouldBe
+import kotlin.test.Test
+
+class StateMappingSymbolProcessorTests {
+    @Test
+    fun `State mapping methods are generated`() {
+        // Arrange
+        val compilation = KotlinCompilation().apply {
+            sources = listOf(SourceFiles.settingsState, SourceFiles.appState)
+            symbolProcessorProviders = listOf(StateMappingSymbolProcessorProvider())
+            inheritClassPath = true
+            messageOutputStream = System.out
+        }
+
+        // Act
+        val result = compilation.compile()
+
+        // Assert
+        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
+
+        val sources = result.kspGeneratedSources()
+        sources.size.shouldBe(1)
+        sources.single().readText().shouldBe(SourceFiles.generatedStateExtensionsFile)
+    }
+}

--- a/komposable-architecture-compiler/src/test/kotlin/StateMappingSymbolProcessorTests.kt
+++ b/komposable-architecture-compiler/src/test/kotlin/StateMappingSymbolProcessorTests.kt
@@ -2,7 +2,6 @@ import com.toggl.komposable.processors.StateMappingSymbolProcessorProvider
 import com.tschuchort.compiletesting.KotlinCompilation
 import com.tschuchort.compiletesting.symbolProcessorProviders
 import io.kotest.matchers.shouldBe
-import sources.ActionSources
 import sources.StateSources
 import kotlin.test.Test
 
@@ -47,5 +46,26 @@ class StateMappingSymbolProcessorTests {
         val sources = result.kspGeneratedSources()
         sources.size.shouldBe(1)
         sources.single().readText().shouldBe(StateSources.generatedStateExtensionsFileWithPathMapping)
+    }
+
+    @Test
+    fun `State mapping methods are generated even when there are nested @ParentPath annotated props`() {
+        // Arrange
+        val compilation = KotlinCompilation().apply {
+            sources = listOf(StateSources.settingsStateWithNestedMapping, StateSources.appStateWithNestedValue)
+            symbolProcessorProviders = listOf(StateMappingSymbolProcessorProvider())
+            inheritClassPath = true
+            messageOutputStream = System.out
+        }
+
+        // Act
+        val result = compilation.compile()
+
+        // Assert
+        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
+
+        val sources = result.kspGeneratedSources()
+        sources.size.shouldBe(1)
+        sources.single().readText().shouldBe(StateSources.generatedStateExtensionsFileWithPathNestedMapping)
     }
 }

--- a/komposable-architecture-compiler/src/test/kotlin/StateMappingSymbolProcessorTests.kt
+++ b/komposable-architecture-compiler/src/test/kotlin/StateMappingSymbolProcessorTests.kt
@@ -2,6 +2,8 @@ import com.toggl.komposable.processors.StateMappingSymbolProcessorProvider
 import com.tschuchort.compiletesting.KotlinCompilation
 import com.tschuchort.compiletesting.symbolProcessorProviders
 import io.kotest.matchers.shouldBe
+import sources.ActionSources
+import sources.StateSources
 import kotlin.test.Test
 
 class StateMappingSymbolProcessorTests {
@@ -9,7 +11,7 @@ class StateMappingSymbolProcessorTests {
     fun `State mapping methods are generated`() {
         // Arrange
         val compilation = KotlinCompilation().apply {
-            sources = listOf(SourceFiles.settingsState, SourceFiles.appState)
+            sources = listOf(StateSources.settingsState, StateSources.appState)
             symbolProcessorProviders = listOf(StateMappingSymbolProcessorProvider())
             inheritClassPath = true
             messageOutputStream = System.out
@@ -23,6 +25,27 @@ class StateMappingSymbolProcessorTests {
 
         val sources = result.kspGeneratedSources()
         sources.size.shouldBe(1)
-        sources.single().readText().shouldBe(SourceFiles.generatedStateExtensionsFile)
+        sources.single().readText().shouldBe(StateSources.generatedStateExtensionsFile)
+    }
+
+    @Test
+    fun `State mapping methods are generated even when there are @ParentPath annotated props`() {
+        // Arrange
+        val compilation = KotlinCompilation().apply {
+            sources = listOf(StateSources.settingsStateWithMapping, StateSources.appState)
+            symbolProcessorProviders = listOf(StateMappingSymbolProcessorProvider())
+            inheritClassPath = true
+            messageOutputStream = System.out
+        }
+
+        // Act
+        val result = compilation.compile()
+
+        // Assert
+        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
+
+        val sources = result.kspGeneratedSources()
+        sources.size.shouldBe(1)
+        sources.single().readText().shouldBe(StateSources.generatedStateExtensionsFileWithPathMapping)
     }
 }

--- a/komposable-architecture-compiler/src/test/kotlin/sources/ActionSources.kt
+++ b/komposable-architecture-compiler/src/test/kotlin/sources/ActionSources.kt
@@ -1,16 +1,9 @@
+package sources
+
 import com.tschuchort.compiletesting.SourceFile
 import org.intellij.lang.annotations.Language
 
-object SourceFiles {
-
-    val settingsState = SourceFile.kotlin(
-        "SettingsState.kt",
-        """
-        package com.toggl.komposable.compiler
-        
-        data class SettingsState(val booleanValue: Boolean)
-        """.trimIndent(),
-    )
+object ActionSources {
 
     val settingsAction = SourceFile.kotlin(
         "SettingsAction.kt",
@@ -29,22 +22,6 @@ object SourceFiles {
     sealed interface SettingsAction {
         data class ChangeSomeSetting(val newValue: Boolean) : SettingsAction
     }
-        """.trimIndent(),
-    )
-
-    val appState = SourceFile.kotlin(
-        "AppState.kt",
-        """
-        package com.toggl.komposable.compiler
-        
-        import com.toggl.komposable.architecture.ChildStates
-        import com.toggl.komposable.compiler.SettingsState
-        
-        @ChildStates(SettingsState::class)
-        data class AppState(
-            val someList: List<String>,
-            val booleanValue: Boolean
-        )
         """.trimIndent(),
     )
 
@@ -114,18 +91,5 @@ public fun mapAppActionToSettingsAction(appAction: AppAction): SettingsAction? =
 
 public fun mapSettingsActionToAppAction(settingsAction: SettingsAction): AppAction.Settings =
     AppAction.Settings(settingsAction)
-"""
-
-    @Language("kotlin")
-    val generatedStateExtensionsFile = """package com.toggl.komposable.compiler
-
-public fun mapAppStateToSettingsState(appState: AppState): SettingsState = SettingsState(
-    booleanValue = appState.booleanValue,
-)
-
-public fun mapSettingsStateToAppState(appState: AppState, settingsState: SettingsState): AppState =
-    appState.copy(
-        booleanValue = settingsState.booleanValue,
-    )
 """
 }

--- a/komposable-architecture-compiler/src/test/kotlin/sources/StateSources.kt
+++ b/komposable-architecture-compiler/src/test/kotlin/sources/StateSources.kt
@@ -1,0 +1,72 @@
+package sources
+
+import com.tschuchort.compiletesting.SourceFile
+import org.intellij.lang.annotations.Language
+
+object StateSources {
+
+    val settingsState = SourceFile.kotlin(
+        "SettingsState.kt",
+        """
+        package com.toggl.komposable.compiler
+        
+        data class SettingsState(val booleanValue: Boolean)
+        """.trimIndent(),
+    )
+
+    val settingsStateWithMapping = SourceFile.kotlin(
+        "SettingsState.kt",
+        """
+        package com.toggl.komposable.compiler
+        
+        import com.toggl.komposable.architecture.ParentPath
+        
+        data class SettingsState(
+            @ParentPath("booleanValue")
+            val value: Boolean
+        )
+        """.trimIndent(),
+    )
+
+    val appState = SourceFile.kotlin(
+        "AppState.kt",
+        """
+        package com.toggl.komposable.compiler
+        
+        import com.toggl.komposable.architecture.ChildStates
+        import com.toggl.komposable.compiler.SettingsState
+        
+        @ChildStates(SettingsState::class)
+        data class AppState(
+            val someList: List<String>,
+            val booleanValue: Boolean
+        )
+        """.trimIndent(),
+    )
+
+    @Language("kotlin")
+    val generatedStateExtensionsFile = """package com.toggl.komposable.compiler
+
+public fun mapAppStateToSettingsState(appState: AppState): SettingsState = SettingsState(
+    booleanValue = appState.booleanValue,
+)
+
+public fun mapSettingsStateToAppState(appState: AppState, settingsState: SettingsState): AppState =
+    appState.copy(
+        booleanValue = settingsState.booleanValue,
+    )
+"""
+
+    @Language("kotlin")
+    val generatedStateExtensionsFileWithPathMapping = """package com.toggl.komposable.compiler
+
+public fun mapAppStateToSettingsState(appState: AppState): SettingsState = SettingsState(
+    value = appState.booleanValue,
+)
+
+public fun mapSettingsStateToAppState(appState: AppState, settingsState: SettingsState): AppState =
+    appState.copy(
+        booleanValue = settingsState.value,
+    )
+"""
+}

--- a/komposable-architecture-compiler/src/test/kotlin/sources/StateSources.kt
+++ b/komposable-architecture-compiler/src/test/kotlin/sources/StateSources.kt
@@ -28,6 +28,20 @@ object StateSources {
         """.trimIndent(),
     )
 
+    val settingsStateWithNestedMapping = SourceFile.kotlin(
+        "SettingsState.kt",
+        """
+        package com.toggl.komposable.compiler
+        
+        import com.toggl.komposable.architecture.ParentPath
+        
+        data class SettingsState(
+            @ParentPath("nested.booleanValue")
+            val value: Boolean
+        )
+        """.trimIndent(),
+    )
+
     val appState = SourceFile.kotlin(
         "AppState.kt",
         """
@@ -40,6 +54,26 @@ object StateSources {
         data class AppState(
             val someList: List<String>,
             val booleanValue: Boolean
+        )
+        """.trimIndent(),
+    )
+
+    val appStateWithNestedValue = SourceFile.kotlin(
+        "AppState.kt",
+        """
+        package com.toggl.komposable.compiler
+        
+        import com.toggl.komposable.architecture.ChildStates
+        import com.toggl.komposable.compiler.SettingsState
+    
+        data class NestedValue(
+            val booleanValue: Boolean
+        )
+        
+        @ChildStates(SettingsState::class)
+        data class AppState(
+            val someList: List<String>,
+            val nested: NestedValue
         )
         """.trimIndent(),
     )
@@ -67,6 +101,21 @@ public fun mapAppStateToSettingsState(appState: AppState): SettingsState = Setti
 public fun mapSettingsStateToAppState(appState: AppState, settingsState: SettingsState): AppState =
     appState.copy(
         booleanValue = settingsState.value,
+    )
+"""
+
+    @Language("kotlin")
+    val generatedStateExtensionsFileWithPathNestedMapping = """package com.toggl.komposable.compiler
+
+public fun mapAppStateToSettingsState(appState: AppState): SettingsState = SettingsState(
+    value = appState.nested.booleanValue,
+)
+
+public fun mapSettingsStateToAppState(appState: AppState, settingsState: SettingsState): AppState =
+    appState.copy(
+        nested = appState.nested.copy(
+            booleanValue = settingsState.value,
+        )
     )
 """
 }

--- a/komposable-architecture/src/main/java/com/toggl/komposable/architecture/Annotations.kt
+++ b/komposable-architecture/src/main/java/com/toggl/komposable/architecture/Annotations.kt
@@ -1,0 +1,15 @@
+package com.toggl.komposable.architecture
+
+import kotlin.reflect.KClass
+
+@Target(AnnotationTarget.CLASS)
+@Retention(AnnotationRetention.SOURCE)
+annotation class WrapperAction
+
+@Target(AnnotationTarget.CLASS)
+@Retention(AnnotationRetention.SOURCE)
+annotation class ChildStates(vararg val childStates: KClass<*>)
+
+@Target(AnnotationTarget.PROPERTY)
+@Retention(AnnotationRetention.SOURCE)
+annotation class ParentPath(val path: String)

--- a/komposable-architecture/src/main/java/com/toggl/komposable/architecture/WrapperAction.kt
+++ b/komposable-architecture/src/main/java/com/toggl/komposable/architecture/WrapperAction.kt
@@ -1,5 +1,0 @@
-package com.toggl.komposable.architecture
-
-@Target(AnnotationTarget.CLASS)
-@Retention(AnnotationRetention.SOURCE)
-annotation class WrapperAction


### PR DESCRIPTION
## Summary
This adds state generation capabilities using KSP, similar to what we already have for actions.

## Relationships
Point 3 of #60 

## Technical considerations
We should create tests that verify more complex scenarios and we should start using these in the samples ASAP to make sure they work in the wild and not only in a vacuum, but the existing tests cover simple mapping, children having different property names because they have more context and nested properties, which, from experience, covers most use cases.

The `@ParentPath` property is stringly types, but you do get a decent compiler error if the parent property changes, so it's still fairly safe! 

## Review pointers
Make sure that the code is readable (or: as readable as KSP can be since there's a lot of shenanigans).

## Merge permissions
Get this in ASAP as possible.